### PR TITLE
Make sure available_range is zero based to reflect source_range.

### DIFF
--- a/Python/Startup/otioexporter/OTIOExportTask.py
+++ b/Python/Startup/otioexporter/OTIOExportTask.py
@@ -74,7 +74,7 @@ class OTIOExportTask(hiero.core.TaskBase):
         available_range = None
         if hiero_clip.mediaSource().isMediaPresent():
             start_time = otio.opentime.RationalTime(
-                hiero_clip.mediaSource().startTime(),
+                0,
                 source_rate
             )
             duration = otio.opentime.RationalTime(


### PR DESCRIPTION
Treat image sequences the same as "movie" based clips and start `available_range` at 0